### PR TITLE
Resync app-permissions overrides with current API schema

### DIFF
--- a/scripts/overrides/get-app-installations.deref.json
+++ b/scripts/overrides/get-app-installations.deref.json
@@ -456,9 +456,9 @@
                       "description": "The level of permission to grant the access token to view and manage users blocked by the organization.",
                       "enum": ["read", "write"]
                     },
-                    "team_discussions": {
+                    "discussions": {
                       "type": "string",
-                      "description": "The level of permission to grant the access token to manage team discussions and related comments.",
+                      "description": "The level of permission to grant the access token for discussions and related comments and labels.",
                       "enum": ["read", "write"]
                     }
                   },

--- a/scripts/overrides/get-app-installations.deref.json
+++ b/scripts/overrides/get-app-installations.deref.json
@@ -1,7 +1,9 @@
 {
   "summary": "List installations for the authenticated app",
   "description": "You must use a [JWT](https://docs.github.com/enterprise-server@3.9/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
-  "tags": ["apps"],
+  "tags": [
+    "apps"
+  ],
   "operationId": "apps/list-installations",
   "externalDocs": {
     "description": "API method documentation",
@@ -257,7 +259,10 @@
                 "repository_selection": {
                   "description": "Describe whether all repositories have been selected or there's a selection involved",
                   "type": "string",
-                  "enum": ["all", "selected"]
+                  "enum": [
+                    "all",
+                    "selected"
+                  ]
                 },
                 "access_tokens_url": {
                   "type": "string",
@@ -294,172 +299,433 @@
                     "actions": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for GitHub Actions workflows, workflow runs, and artifacts.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "administration": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for repository creation, deletion, settings, teams, and collaborators creation.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "artifact_metadata": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to create and retrieve build artifact metadata records.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "attestations": {
+                      "type": "string",
+                      "description": "The level of permission to create and retrieve the access token for repository attestations.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "checks": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for checks on code.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "codespaces": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to create, edit, delete, and list Codespaces.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "contents": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for repository contents, commits, branches, downloads, releases, and merges.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "custom_properties_for_organizations": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and edit custom properties for an organization, when allowed by the property.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "dependabot_secrets": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage Dependabot secrets.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "deployments": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for deployments and deployment statuses.",
-                      "enum": ["read", "write"]
-                    },
-                    "environments": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for managing repository environments.",
-                      "enum": ["read", "write"]
-                    },
-                    "issues": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for issues and related comments, assignees, labels, and milestones.",
-                      "enum": ["read", "write"]
-                    },
-                    "metadata": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to search repositories, list collaborators, and access repository metadata.",
-                      "enum": ["read", "write"]
-                    },
-                    "packages": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for packages published to GitHub Packages.",
-                      "enum": ["read", "write"]
-                    },
-                    "pages": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to retrieve Pages statuses, configuration, and builds, as well as create new builds.",
-                      "enum": ["read", "write"]
-                    },
-                    "pull_requests": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for pull requests and related comments, assignees, labels, milestones, and merges.",
-                      "enum": ["read", "write"]
-                    },
-                    "repository_hooks": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage the post-receive hooks for a repository.",
-                      "enum": ["read", "write"]
-                    },
-                    "repository_projects": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage repository projects, columns, and cards.",
-                      "enum": ["read", "write", "admin"]
-                    },
-                    "secret_scanning_alerts": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage secret scanning alerts.",
-                      "enum": ["read", "write"]
-                    },
-                    "secrets": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage repository secrets.",
-                      "enum": ["read", "write"]
-                    },
-                    "security_events": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage security events like code scanning alerts.",
-                      "enum": ["read", "write"]
-                    },
-                    "single_file": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage just a single file.",
-                      "enum": ["read", "write"]
-                    },
-                    "statuses": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for commit statuses.",
-                      "enum": ["read", "write"]
-                    },
-                    "vulnerability_alerts": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage Dependabot alerts.",
-                      "enum": ["read", "write"]
-                    },
-                    "workflows": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to update GitHub Actions workflow files.",
-                      "enum": ["write"]
-                    },
-                    "members": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for organization teams and members.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_administration": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage access to an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_custom_roles": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for custom repository roles management. This property is in beta and is subject to change.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_announcement_banners": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage announcement banners for an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_hooks": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage the post-receive hooks for an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_personal_access_tokens": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for viewing and managing fine-grained personal access token requests to an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_personal_access_token_requests": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for viewing and managing fine-grained personal access tokens that have been approved by an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_plan": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for viewing an organization's plan.",
-                      "enum": ["read"]
-                    },
-                    "organization_projects": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage organization projects and projects beta (where available).",
-                      "enum": ["read", "write", "admin"]
-                    },
-                    "organization_packages": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for organization packages published to GitHub Packages.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_secrets": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage organization secrets.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_self_hosted_runners": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage GitHub Actions self-hosted runners available to an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_user_blocking": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage users blocked by the organization.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "discussions": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for discussions and related comments and labels.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "email_addresses": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the email addresses belonging to a user.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "enterprise_custom_properties_for_organizations": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for organization custom properties management at the enterprise level.",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ]
+                    },
+                    "environments": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for managing repository environments.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "followers": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the followers belonging to a user.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "git_ssh_keys": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage git SSH keys.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "gpg_keys": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage GPG keys belonging to a user.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "interaction_limits": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage interaction limits on a repository.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "issues": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for issues and related comments, assignees, labels, and milestones.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "members": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for organization teams and members.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "merge_queues": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the merge queues for a repository.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "metadata": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to search repositories, list collaborators, and access repository metadata.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_administration": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage access to an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_announcement_banners": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage announcement banners for an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_copilot_agent_settings": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage Copilot coding agent settings for an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_copilot_seat_management": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for managing access to GitHub Copilot for members of an organization with a Copilot Business subscription. This property is in public preview and is subject to change.",
+                      "enum": [
+                        "write"
+                      ]
+                    },
+                    "organization_custom_org_roles": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for custom organization roles management.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_custom_properties": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for repository custom properties management at the organization level.",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ]
+                    },
+                    "organization_custom_roles": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for custom repository roles management.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_events": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view events triggered by an activity in an organization.",
+                      "enum": [
+                        "read"
+                      ]
+                    },
+                    "organization_hooks": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the post-receive hooks for an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_packages": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for organization packages published to GitHub Packages.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_personal_access_token_requests": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for viewing and managing fine-grained personal access tokens that have been approved by an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_personal_access_tokens": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for viewing and managing fine-grained personal access token requests to an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_plan": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for viewing an organization's plan.",
+                      "enum": [
+                        "read"
+                      ]
+                    },
+                    "organization_projects": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage organization projects and projects public preview (where available).",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ]
+                    },
+                    "organization_secrets": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage organization secrets.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_self_hosted_runners": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage GitHub Actions self-hosted runners available to an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_user_blocking": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage users blocked by the organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "packages": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for packages published to GitHub Packages.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "pages": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to retrieve Pages statuses, configuration, and builds, as well as create new builds.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "profile": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the profile settings belonging to a user.",
+                      "enum": [
+                        "write"
+                      ]
+                    },
+                    "pull_requests": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for pull requests and related comments, assignees, labels, milestones, and merges.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "repository_custom_properties": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and edit custom properties for a repository, when allowed by the property.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "repository_hooks": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the post-receive hooks for a repository.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "repository_projects": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage repository projects, columns, and cards.",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ]
+                    },
+                    "secret_scanning_alerts": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage secret scanning alerts.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "secrets": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage repository secrets.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "security_events": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage security events like code scanning alerts.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "single_file": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage just a single file.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "starring": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to list and manage repositories a user is starring.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "statuses": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for commit statuses.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "vulnerability_alerts": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage Dependabot alerts.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "workflows": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to update GitHub Actions workflow files.",
+                      "enum": [
+                        "write"
+                      ]
                     }
                   },
                   "example": {
@@ -497,7 +763,10 @@
                   "items": {
                     "type": "string"
                   },
-                  "example": ["config.yml", ".github/issue_TEMPLATE.md"]
+                  "example": [
+                    "config.yml",
+                    ".github/issue_TEMPLATE.md"
+                  ]
                 },
                 "app_slug": {
                   "type": "string",
@@ -691,7 +960,10 @@
                     "metadata": "read",
                     "contents": "read"
                   },
-                  "events": ["push", "pull_request"],
+                  "events": [
+                    "push",
+                    "pull_request"
+                  ],
                   "single_file_name": "config.yaml",
                   "has_multiple_single_files": true,
                   "single_file_paths": [

--- a/scripts/overrides/get-app-installations.json
+++ b/scripts/overrides/get-app-installations.json
@@ -1,7 +1,9 @@
 {
   "summary": "List installations for the authenticated app",
   "description": "You must use a [JWT](https://docs.github.com/enterprise-server@3.9/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint.\n\nThe permissions the installation has are included under the `permissions` key.",
-  "tags": ["apps"],
+  "tags": [
+    "apps"
+  ],
   "operationId": "apps/list-installations",
   "externalDocs": {
     "description": "API method documentation",
@@ -238,7 +240,10 @@
                 "repository_selection": {
                   "description": "Describe whether all repositories have been selected or there's a selection involved",
                   "type": "string",
-                  "enum": ["all", "selected"]
+                  "enum": [
+                    "all",
+                    "selected"
+                  ]
                 },
                 "access_tokens_url": {
                   "type": "string",
@@ -275,172 +280,433 @@
                     "actions": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for GitHub Actions workflows, workflow runs, and artifacts.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "administration": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for repository creation, deletion, settings, teams, and collaborators creation.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "artifact_metadata": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to create and retrieve build artifact metadata records.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "attestations": {
+                      "type": "string",
+                      "description": "The level of permission to create and retrieve the access token for repository attestations.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "checks": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for checks on code.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "codespaces": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to create, edit, delete, and list Codespaces.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "contents": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for repository contents, commits, branches, downloads, releases, and merges.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "custom_properties_for_organizations": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and edit custom properties for an organization, when allowed by the property.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "dependabot_secrets": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage Dependabot secrets.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "deployments": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for deployments and deployment statuses.",
-                      "enum": ["read", "write"]
-                    },
-                    "environments": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for managing repository environments.",
-                      "enum": ["read", "write"]
-                    },
-                    "issues": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for issues and related comments, assignees, labels, and milestones.",
-                      "enum": ["read", "write"]
-                    },
-                    "metadata": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to search repositories, list collaborators, and access repository metadata.",
-                      "enum": ["read", "write"]
-                    },
-                    "packages": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for packages published to GitHub Packages.",
-                      "enum": ["read", "write"]
-                    },
-                    "pages": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to retrieve Pages statuses, configuration, and builds, as well as create new builds.",
-                      "enum": ["read", "write"]
-                    },
-                    "pull_requests": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for pull requests and related comments, assignees, labels, milestones, and merges.",
-                      "enum": ["read", "write"]
-                    },
-                    "repository_hooks": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage the post-receive hooks for a repository.",
-                      "enum": ["read", "write"]
-                    },
-                    "repository_projects": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage repository projects, columns, and cards.",
-                      "enum": ["read", "write", "admin"]
-                    },
-                    "secret_scanning_alerts": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage secret scanning alerts.",
-                      "enum": ["read", "write"]
-                    },
-                    "secrets": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage repository secrets.",
-                      "enum": ["read", "write"]
-                    },
-                    "security_events": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage security events like code scanning alerts.",
-                      "enum": ["read", "write"]
-                    },
-                    "single_file": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage just a single file.",
-                      "enum": ["read", "write"]
-                    },
-                    "statuses": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for commit statuses.",
-                      "enum": ["read", "write"]
-                    },
-                    "vulnerability_alerts": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage Dependabot alerts.",
-                      "enum": ["read", "write"]
-                    },
-                    "workflows": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to update GitHub Actions workflow files.",
-                      "enum": ["write"]
-                    },
-                    "members": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for organization teams and members.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_administration": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage access to an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_custom_roles": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for custom repository roles management. This property is in beta and is subject to change.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_announcement_banners": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage announcement banners for an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_hooks": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage the post-receive hooks for an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_personal_access_tokens": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for viewing and managing fine-grained personal access token requests to an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_personal_access_token_requests": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for viewing and managing fine-grained personal access tokens that have been approved by an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_plan": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for viewing an organization's plan.",
-                      "enum": ["read"]
-                    },
-                    "organization_projects": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage organization projects and projects beta (where available).",
-                      "enum": ["read", "write", "admin"]
-                    },
-                    "organization_packages": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token for organization packages published to GitHub Packages.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_secrets": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to manage organization secrets.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_self_hosted_runners": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage GitHub Actions self-hosted runners available to an organization.",
-                      "enum": ["read", "write"]
-                    },
-                    "organization_user_blocking": {
-                      "type": "string",
-                      "description": "The level of permission to grant the access token to view and manage users blocked by the organization.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
                     },
                     "discussions": {
                       "type": "string",
                       "description": "The level of permission to grant the access token for discussions and related comments and labels.",
-                      "enum": ["read", "write"]
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "email_addresses": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the email addresses belonging to a user.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "enterprise_custom_properties_for_organizations": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for organization custom properties management at the enterprise level.",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ]
+                    },
+                    "environments": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for managing repository environments.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "followers": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the followers belonging to a user.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "git_ssh_keys": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage git SSH keys.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "gpg_keys": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage GPG keys belonging to a user.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "interaction_limits": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage interaction limits on a repository.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "issues": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for issues and related comments, assignees, labels, and milestones.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "members": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for organization teams and members.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "merge_queues": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the merge queues for a repository.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "metadata": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to search repositories, list collaborators, and access repository metadata.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_administration": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage access to an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_announcement_banners": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage announcement banners for an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_copilot_agent_settings": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage Copilot coding agent settings for an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_copilot_seat_management": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for managing access to GitHub Copilot for members of an organization with a Copilot Business subscription. This property is in public preview and is subject to change.",
+                      "enum": [
+                        "write"
+                      ]
+                    },
+                    "organization_custom_org_roles": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for custom organization roles management.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_custom_properties": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for repository custom properties management at the organization level.",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ]
+                    },
+                    "organization_custom_roles": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for custom repository roles management.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_events": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view events triggered by an activity in an organization.",
+                      "enum": [
+                        "read"
+                      ]
+                    },
+                    "organization_hooks": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the post-receive hooks for an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_packages": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for organization packages published to GitHub Packages.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_personal_access_token_requests": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for viewing and managing fine-grained personal access tokens that have been approved by an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_personal_access_tokens": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for viewing and managing fine-grained personal access token requests to an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_plan": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for viewing an organization's plan.",
+                      "enum": [
+                        "read"
+                      ]
+                    },
+                    "organization_projects": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage organization projects and projects public preview (where available).",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ]
+                    },
+                    "organization_secrets": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage organization secrets.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_self_hosted_runners": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage GitHub Actions self-hosted runners available to an organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "organization_user_blocking": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage users blocked by the organization.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "packages": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for packages published to GitHub Packages.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "pages": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to retrieve Pages statuses, configuration, and builds, as well as create new builds.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "profile": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the profile settings belonging to a user.",
+                      "enum": [
+                        "write"
+                      ]
+                    },
+                    "pull_requests": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for pull requests and related comments, assignees, labels, milestones, and merges.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "repository_custom_properties": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and edit custom properties for a repository, when allowed by the property.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "repository_hooks": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage the post-receive hooks for a repository.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "repository_projects": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage repository projects, columns, and cards.",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ]
+                    },
+                    "secret_scanning_alerts": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage secret scanning alerts.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "secrets": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage repository secrets.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "security_events": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to view and manage security events like code scanning alerts.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "single_file": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage just a single file.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "starring": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to list and manage repositories a user is starring.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "statuses": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token for commit statuses.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "vulnerability_alerts": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to manage Dependabot alerts.",
+                      "enum": [
+                        "read",
+                        "write"
+                      ]
+                    },
+                    "workflows": {
+                      "type": "string",
+                      "description": "The level of permission to grant the access token to update GitHub Actions workflow files.",
+                      "enum": [
+                        "write"
+                      ]
                     }
                   },
                   "example": {
@@ -478,7 +744,10 @@
                   "items": {
                     "type": "string"
                   },
-                  "example": ["config.yml", ".github/issue_TEMPLATE.md"]
+                  "example": [
+                    "config.yml",
+                    ".github/issue_TEMPLATE.md"
+                  ]
                 },
                 "app_slug": {
                   "type": "string",

--- a/scripts/overrides/get-app-installations.json
+++ b/scripts/overrides/get-app-installations.json
@@ -437,9 +437,9 @@
                       "description": "The level of permission to grant the access token to view and manage users blocked by the organization.",
                       "enum": ["read", "write"]
                     },
-                    "team_discussions": {
+                    "discussions": {
                       "type": "string",
-                      "description": "The level of permission to grant the access token to manage team discussions and related comments.",
+                      "description": "The level of permission to grant the access token for discussions and related comments and labels.",
                       "enum": ["read", "write"]
                     }
                   },


### PR DESCRIPTION
## Problem

The override files for `/app/installations` (`scripts/overrides/get-app-installations.json` and `.deref.json`) contained a stale copy of the `app-permissions` schema. The most impactful issue was using the old `team_discussions` key instead of `discussions`, but the permissions block had also drifted significantly — missing 20 permissions that exist in the current GitHub API.

## Root Cause

These overrides exist to work around a `anyOf` issue ([octokit/openapi-types.ts#305](https://github.com/octokit/openapi-types.ts/issues/305)). The `replaceOperation()` function in `scripts/overrides/index.mjs` replaces the **entire** operation with a frozen JSON snapshot, which means the permissions block drifts every time GitHub adds a new permission scope upstream.

Ideally, the override would only patch the `anyOf` structure rather than replacing the whole operation — that way permissions would stay in sync automatically. That's a bigger refactor but would prevent this class of drift entirely.

## Fix

- Renamed `team_discussions` → `discussions` with updated description
- Added 20 missing permissions to align with the current `app-permissions` schema: `artifact_metadata`, `attestations`, `codespaces`, `custom_properties_for_organizations`, `dependabot_secrets`, `email_addresses`, `enterprise_custom_properties_for_organizations`, `followers`, `git_ssh_keys`, `gpg_keys`, `interaction_limits`, `merge_queues`, `organization_copilot_agent_settings`, `organization_copilot_seat_management`, `organization_custom_org_roles`, `organization_custom_properties`, `organization_events`, `profile`, `repository_custom_properties`, `starring`
- Both override files now contain all 54 permissions matching the live API schema exactly (types, enums, and descriptions verified)

## Impact

Downstream consumers (e.g. `actions/create-github-app-token`) that generate permission inputs from `app-permissions` will now correctly see `discussions` instead of `team_discussions`, and will have access to all current permission scopes.

This also helps fix https://github.com/github/gh-aw/pull/25709 due to the regression from https://github.com/github/gh-aw/pull/25508.

Fixes #528